### PR TITLE
Adapt creds/http_form_* modules to Cisco Docsis

### DIFF
--- a/routersploit/modules/creds/http_form_default.py
+++ b/routersploit/modules/creds/http_form_default.py
@@ -34,6 +34,7 @@ class Exploit(exploits.Exploit):
     defaults = exploits.Option(wordlists.defaults, 'User:Pass or file with default credentials (file://)')
     form = exploits.Option('auto', 'Post Data: auto or in form login={{LOGIN}}&password={{PASS}}&submit')
     path = exploits.Option('/login.php', 'URL Path')
+    form_path = exploits.Option('same', 'same as path or URL Form Path')
     verbosity = exploits.Option('yes', 'Display authentication attempts')
 
     credentials = []
@@ -44,9 +45,15 @@ class Exploit(exploits.Exploit):
         self.credentials = []
         self.attack()
 
+    def get_form_path(self):
+        if self.form_path == 'same':
+            return self.path
+        else:
+            return self.form_path
+
     @multi
     def attack(self):
-        url = sanitize_url("{}:{}{}".format(self.target, self.port, self.path))
+        url = sanitize_url("{}:{}{}".format(self.target, self.port, self.get_form_path()))
 
         try:
             requests.get(url, verify=False)
@@ -59,11 +66,15 @@ class Exploit(exploits.Exploit):
 
         # authentication type
         if self.form == 'auto':
-            self.data = self.detect_form()
+            form_data = self.detect_form()
 
-            if self.data is None:
+            if form_data is None:
                 print_error("Could not detect form")
                 return
+
+            (form_action, self.data) = form_data
+            if form_action:
+                self.path = form_action
         else:
             self.data = self.form
 
@@ -109,7 +120,7 @@ class Exploit(exploits.Exploit):
                 self.invalid["max"] = l
 
     def detect_form(self):
-        url = sanitize_url("{}:{}{}".format(self.target, self.port, self.path))
+        url = sanitize_url("{}:{}{}".format(self.target, self.port, self.get_form_path()))
         r = requests.get(url, verify=False)
         soup = BeautifulSoup(r.text, "lxml")
 
@@ -118,20 +129,22 @@ class Exploit(exploits.Exploit):
         if form is None:
             return None
 
+        action = form.attrs.get('action', None)
+
         if len(form) > 0:
             res = []
             for inp in form.findAll("input"):
                 if 'name' in inp.attrs.keys():
-                    if inp.attrs['name'].lower() in ["username", "user", "login"]:
+                    if inp.attrs['name'].lower() in ["username", "user", "login", "username_login"]:
                         res.append(inp.attrs['name'] + "=" + "{{USER}}")
-                    elif inp.attrs['name'].lower() in ["password", "pass"]:
+                    elif inp.attrs['name'].lower() in ["password", "pass", "password_login"]:
                         res.append(inp.attrs['name'] + "=" + "{{PASS}}")
                     else:
                         if 'value' in inp.attrs.keys():
                             res.append(inp.attrs['name'] + "=" + inp.attrs['value'])
                         else:
                             res.append(inp.attrs['name'] + "=")
-        return '&'.join(res)
+        return (action, '&'.join(res))
 
     def target_function(self, running, data):
         module_verbosity = boolify(self.verbosity)


### PR DESCRIPTION
# New option `form_path` created

Cisco Docsis has two different urls:

- `GET /Docsis_system.asp` (login form is here)
- `POST /goform/Docsis_system` (actual login entrypoint)

Right now routersploit expects that the same URL could serve `GET` as well as `POST` requests.

You can leave it `same` as `path` value.

# Form action autodetect

All you need is specify `form_path`, `path` option will be set from `<form action="VALUE">` attribute.

# New input tokens

Cisco Docsis uses `username_login` and `password_login` as input names, so I have added them to default list.

[![asciicast](https://asciinema.org/a/d92znqtma32v37gs3h7d0vst9.png)](https://asciinema.org/a/d92znqtma32v37gs3h7d0vst9)