### PR TITLE
s/env python/env python2/

### DIFF
--- a/rsf.py
+++ b/rsf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from routersploit.interpreter import RoutersploitInterpreter
 


### PR DESCRIPTION
In some distributions, e.g. archlinux,
'python' symlinked to python3, which throws InvalidSyntax