### PR TITLE
Fix hg630a if paramiko ssh trows no valid connections

### DIFF
--- a/routersploit/modules/exploits/huawei/hg630a_default_creds.py
+++ b/routersploit/modules/exploits/huawei/hg630a_default_creds.py
@@ -87,7 +87,7 @@ class Exploit(exploits.Exploit):
 
         try:
             ssh.connect(self.target, 22, timeout=5, username=self.user, password=self.password)
-        except paramiko.ssh_exception.SSHException:
+        except (paramiko.ssh_exception.SSHException, paramiko.ssh_exception.NoValidConnectionsError
             return False  # target is not vulnerable
         else:
             return True  # target is vulnerable


### PR DESCRIPTION
Fix hg630a_default_creds fails  when NoValidConnectionsError