### PR TITLE
fix: OSError: [Errno 2] No such file or directory: 'routersploit/modu…

### DIFF
--- a/routersploit/modules/scanners/dlink_scan.py
+++ b/routersploit/modules/scanners/dlink_scan.py
@@ -7,6 +7,7 @@ from routersploit import (
     print_success,
     print_error,
     print_status,
+    utils,
 )
 
 
@@ -32,17 +33,18 @@ class Exploit(exploits.Exploit):
     port = exploits.Option(80, 'Target port')  # default port
 
     def run(self):
-        rootpath = 'routersploit/modules/'
+        #rootpath = 'routersploit/modules/'
         path = 'exploits/dlink/'
+        dlink_dir = utils.EXPLOITS_DIR + '/dlink'
 
         # only py exploit files
-        modules = [f.replace(".py", "") for f in listdir(rootpath + path) if isfile(join(rootpath + path, f)) and f.endswith(".py") and f != "__init__.py"]
+        modules = [f.replace(".py", "") for f in listdir(dlink_dir) if isfile(join(dlink_dir, f)) and f.endswith(".py") and f != "__init__.py"]
 
         vulns = []
         for module_name in modules:
-            f = path + module_name
+            f = '/' + path + module_name
 
-            module = imp.load_source('module', rootpath + f + '.py')
+            module = imp.load_source('module', utils.MODULES_DIR + f + '.py')
             exploit = module.Exploit()
 
             exploit.target = self.target

--- a/routersploit/modules/scanners/dlink_scan.py
+++ b/routersploit/modules/scanners/dlink_scan.py
@@ -33,7 +33,7 @@ class Exploit(exploits.Exploit):
     port = exploits.Option(80, 'Target port')  # default port
 
     def run(self):
-        #rootpath = 'routersploit/modules/'
+        # rootpath = 'routersploit/modules/'
         path = 'exploits/dlink/'
         dlink_dir = utils.EXPLOITS_DIR + '/dlink'
 


### PR DESCRIPTION
The commit fix the following error, when using rsf from the command line

```
$ rsf
> use scanners/dlink_scan
> set target 192.168.1.1
> run
[-] Traceback (most recent call last):
  File "/home/kulyzu/Repositories/routersploit/routersploit/interpreter.py", line 288, in command_run
    self.current_module.run()
  File "/home/kulyzu/Repositories/routersploit/routersploit/modules/scanners/dlink_scan.py", line 39, in run
    modules = [f.replace(".py", "") for f in listdir(rootpath + path) if isfile(join(rootpath + path, f)) and f.endswith(".py") and f != "__init__.py"]
OSError: [Errno 2] No such file or directory: 'routersploit/modules/exploits/dlink/'
```

rsf command is:
```
$ la $(which rsf)
lrwxrwxrwx 1 root staff 45 Apr 26 19:14 /usr/local/bin/rsf -> /home/kulyzu/Repositories/routersploit/rsf.py

```