### PR TITLE
fix netcore udp 53413 backdoor - url reference

### DIFF
--- a/routersploit/modules/exploits/netcore/udp_53413_rce.py
+++ b/routersploit/modules/exploits/netcore/udp_53413_rce.py
@@ -23,7 +23,7 @@ class Exploit(exploits.Exploit):
         ],
         'description': 'Exploits Netcore/Netis backdoor functionality that allows executing commands on operating system level.',
         'references': [
-            'https://www.seebug.org/vuldb/ssvid-9022',
+            'https://www.seebug.org/vuldb/ssvid-90227',
             'http://blog.trendmicro.com/trendlabs-security-intelligence/netis-routers-leave-wide-open-backdoor/',
         ],
         'devices': [


### PR DESCRIPTION
Please fix the seebug uri -> https://www.seebug.org/vuldb/ssvid-90227