### PR TITLE
Catch socket.timeout during multi-thread bruteforce (Fix #94).

### DIFF
--- a/routersploit/modules/creds/ssh_bruteforce.py
+++ b/routersploit/modules/creds/ssh_bruteforce.py
@@ -102,7 +102,7 @@ class Exploit(exploits.Exploit):
                 ssh.connect(self.target, int(self.port), timeout=5, username=user, password=password)
             except StopIteration:
                 break
-            except paramiko.ssh_exception.SSHException as err:
+            except (socket.timeout, paramiko.ssh_exception.SSHException) as err:
                 ssh.close()
                 print_error("Target: {}:{} {}: {} Username: '{}' Password: '{}'".format(self.target, self.port, name, err, user, password), verbose=module_verbosity)
             else:

--- a/routersploit/modules/creds/ssh_default.py
+++ b/routersploit/modules/creds/ssh_default.py
@@ -94,9 +94,8 @@ class Exploit(exploits.Exploit):
                 ssh.connect(self.target, int(self.port), timeout=5, username=user, password=password)
             except StopIteration:
                 break
-            except paramiko.ssh_exception.SSHException as err:
+            except (socket.timeout, paramiko.ssh_exception.SSHException) as err:
                 ssh.close()
-
                 print_error("Target: {}:{} {}: {} Username: '{}' Password: '{}'".format(self.target, self.port, name, err, user, password), verbose=module_verbosity)
             else:
                 if boolify(self.stop_on_success):


### PR DESCRIPTION
According to https://github.com/reverse-shell/routersploit/issues/94, timeout is not properly handled when the SSH bruteforce is running and the target does not support (many) multiple connections.

With this fix, I added `socket.timeout` in the try/catch surrounding the SSH connection in both creds/ssh_bruteforce.py and creds/ssh_default.py.

Now, when a timeout error occurs, routersploit will show an error message similar to when `paramiko.ssh_exception.SSHException` exception occurs (re-using the same `print_error()`)