### PR TITLE
Change print to built-in print_info

### DIFF
--- a/routersploit/modules/exploits/routers/comtrend/ct_5361t_password_disclosure.py
+++ b/routersploit/modules/exploits/routers/comtrend/ct_5361t_password_disclosure.py
@@ -3,8 +3,9 @@ import re
 
 from routersploit import (
     exploits,
-    print_status,
+    print_info,
     print_error,
+    print_status,
     print_success,
     print_table,
     http_request,
@@ -59,7 +60,7 @@ class Exploit(exploits.Exploit):
                 print_success("Credentials found!")
                 headers = ("Login", "Password")
                 print_table(headers, *creds)
-                print("NOTE: Admin is commonly implemented as root")
+                print_info("NOTE: Admin is commonly implemented as root")
             else:
                 print_error("Credentials could not be found")
         else:


### PR DESCRIPTION
Small fix: exploit now uses print_info instead of print. Also put imports into alphabetical order.