### PR TITLE
updated installation for Ubuntu 16.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ It consists of various modules that aids penetration testing operations:
 	sudo apt-get install python-dev python-pip libncurses5-dev git
 	git clone https://github.com/reverse-shell/routersploit
 	cd routersploit
-	pip install -r requirements.txt
+	sudo pip install -r requirements.txt
 	./rsf.py
 
 ## Installation on Centos 7


### PR DESCRIPTION
The mistake was just that for executing: pip install -r requirements.txt
you needed sudo powers, because when you tried to access some python directories, an exception was thrown: OSError: [Errno 13] Permission denied: '/usr/local/lib/python2.7/dist-packages/ply'
So the solution for this was just adding 'sudo':
sudo pip install -r requirements.txt