### PR TITLE
adding default user/password for zhone DSL modems

### DIFF
--- a/routersploit/wordlists/defaults.txt
+++ b/routersploit/wordlists/defaults.txt
@@ -7,6 +7,8 @@ ADMINISTRATOR:ADMINISTRATOR
 ADMN:admn
 ADVMAIL:HP
 ADVMAIL:HPOFFICE
+admin:cciadmin
+admin:zhone
 Admin:admin
 Admin:Admin
 Administrator:3ware

--- a/routersploit/wordlists/passwords.txt
+++ b/routersploit/wordlists/passwords.txt
@@ -243,6 +243,7 @@ calvin
 cascade
 cat1029
 ccrusr
+cciadmin
 cellit
 cgadmin
 changeme
@@ -540,4 +541,5 @@ xxyyzz
 zoomadsl
 zxcvbnm
 zyad1234
+zhone
 Zte521


### PR DESCRIPTION
Hello,

I've added 2 of the default passwords for zhone DSL modem/routers. 

Test:
```
$ python rsf.py
 ______            _            _____       _       _ _
 | ___ \          | |          /  ___|     | |     (_) |
 | |_/ /___  _   _| |_ ___ _ __\ `--. _ __ | | ___  _| |_
 |    // _ \| | | | __/ _ \ '__|`--. \ '_ \| |/ _ \| | __|
 | |\ \ (_) | |_| | ||  __/ |  /\__/ / |_) | | (_) | | |_
 \_| \_\___/ \__,_|\__\___|_|  \____/| .__/|_|\___/|_|\__|
                                     | |
     Router Exploitation Framework   |_|

 Dev Team : Marcin Bury (lucyoa) & Mariusz Kupidura (fwkz)
 Codename : Bad Blood
 Version  : 2.2.1

 Exploits: 117 Scanners: 29 Creds: 13

rsf > use creds/http_basic_default
rsf (HTTP Basic Default Creds) > set
defaults         path             port             stop_on_success  target           threads          verbosity
rsf (HTTP Basic Default Creds) > set target http://192.168.2.1
[+] {'target': 'http://192.168.2.1'}
rsf (HTTP Basic Default Creds) > run
[*] Running module...
<snipped unneeded output>
[+] Target: http://192.168.2.1:80 worker-2: Authentication Succeed - Username: 'admin' Password: 'cciadmin'
<snipped unneeded output>
[*] Waiting for already scheduled jobs to finish...
[*] Elapsed time:  1.10767602921 seconds
[+] Credentials found!

   Target                 Port     Login     Password
   ------                 ----     -----     --------
   http://192.168.2.1     80       admin     cciadmin
```