### PR TITLE
Refactor Dockerfile.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.idea/
+.travis/
+
+README.md
+LICENSE
+.travis.yml
+*.pyc
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM python:2.7
 
-WORKDIR /routersploit
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt
 
-RUN git clone https://github.com/reverse-shell/routersploit/ .
-RUN pip install -r requirements.txt
+WORKDIR /routersploit
+COPY . .
 
 CMD ["python", "rsf.py"]

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,13 @@
-# Makefile that aggregates common chores before commit
-
-.PHONY: all clean lint lint-modules test build update run help
+.PHONY: build run test lint lint-modules clean prune help
 
 MODULE=''
+RSF_IMAGE=routersploit
 
-all: lint test
+build:
+	docker build -t $(RSF_IMAGE) .
 
-clean:
-	find . -name '*.pyc' -exec rm -f {} +
-	find . -name '*.pyo' -exec rm -f {} +
-	find . -name '*~' -exec rm -f  {} +
+run:
+	docker run -it --rm $(RSF_IMAGE)
 
 lint:
 	./run_linter.sh
@@ -20,21 +18,25 @@ lint-modules:
 test: clean
 	./run_tests.sh $(MODULE)
 
-build:
-	docker build -t routersploit:latest -f Dockerfile .
+clean:
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f  {} +
 
-update:
-	./run_docker.sh git pull
-
-run:
-	./run_docker.sh
+prune:
+	docker images -q -f dangling=true | xargs docker rmi
+	docker ps -q -f status=exited | xargs docker rm
 
 help:
-	@echo "    clean"
-	@echo "        Remove python artifacts."
+	@echo "    run"
+	@echo "        Run Routersploit in docker container"
 	@echo "    lint"
 	@echo "        Check style with flake8."
 	@echo "    lint-modules"
 	@echo "        Check modules style with flake8."
 	@echo "    test"
 	@echo "        Run test suite"
+	@echo "    clean"
+	@echo "        Remove python artifacts."
+	@echo "    prune"
+	@echo "        Remove dangling docker images and exited containers."

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-if [ -z $1 ] ; then
-    docker run -it --net host --rm routersploit
-else
-    docker run -it --net host --rm routersploit $@
-fi


### PR DESCRIPTION
- Add base layer with installing requirements to shorten build time.
- Add .dockerignore to reduce amount of files to copy.
- Remove unnecessary `run_docker.sh` script.