### PR TITLE
Add unit test for Interpreter parse_line method

### DIFF
--- a/routersploit/test/test_interpreter.py
+++ b/routersploit/test/test_interpreter.py
@@ -598,6 +598,11 @@ class RoutersploitInterpreterTest(RoutersploitTestCase):
         with self.assertRaises(EOFError):
             self.interpreter.command_exit()
 
+    def test_parse_line(self):
+        cmd, args = self.interpreter.parse_line("show options")
+        self.assertEqual(cmd, "show")
+        self.assertEqual(args, "options")
+
     @mock.patch('os.system')
     def test_command_exec(self, mock_system):
         self.interpreter.command_exec("foo -bar")


### PR DESCRIPTION
This adds a unit test for the parse_line method in routersploit's BaseInterpreter class.