### PR TITLE
Rom-0 exploit - invalid check.

### DIFF
--- a/routersploit/modules/exploits/routers/multi/rom0.py
+++ b/routersploit/modules/exploits/routers/multi/rom0.py
@@ -99,8 +99,8 @@ class Exploit(exploits.Exploit):
 
         if response is not None \
                 and response.status_code == 200 \
-                and "<html>" not in response.text \
-                and len(response.text) > 500:
+                and "<html>" not in response.text:
+                #and len(response.text) > 500:
             return True
 
         return False

--- a/routersploit/modules/exploits/routers/multi/rom0.py
+++ b/routersploit/modules/exploits/routers/multi/rom0.py
@@ -100,7 +100,7 @@ class Exploit(exploits.Exploit):
         if response is not None \
                 and response.status_code == 200 \
                 and "<html>" not in response.text:
-                #and len(response.text) > 500:
+                # and len(response.text) > 500:
             return True
 
         return False


### PR DESCRIPTION
The HTTP HEAD method doesn't return the content of the body, so line:
`and len(response.text) > 500:`
will never be true if second line of check: 
`response = http_request(method="HEAD", url=url)`
get a response.

As result, some devices seem not vulnerable when actually it is.

Data:
```
HEAD /rom-0 HTTP/1.1
Host: 192.168.254.254
Connection: keep-alive
Accept-Encoding: gzip, deflate
Accept: */*
User-Agent: python-requests/2.18.4


HTTP/1.1 200 OK
Content-Type: application/octet-stream
Date: Sat, 01 Jan 2000 00:18:54 GMT
Last-Modified: Wed, 01 Jan 1930 00:18:54 GMT
Content-Length: 16384
Server: RomPager/4.07 UPnP/1.0
EXT:
```

My suggestion is just to comment this line, but I think it is necessary additional checks for routers that return code 200 with html data. 
That's it!