### PR TITLE
Rom-0 exploit - check error

### DIFF
--- a/routersploit/modules/exploits/routers/multi/rom0.py
+++ b/routersploit/modules/exploits/routers/multi/rom0.py
@@ -99,8 +99,8 @@ class Exploit(exploits.Exploit):
 
         if response is not None \
                 and response.status_code == 200 \
-                and "<html>" not in response.text \
-                and len(response.text) > 500:
+                and "html" not in response.headers['Content-Type']:
+                # and len(response.text) > 500:
             return True
 
         return False


### PR DESCRIPTION
The HTTP HEAD method in general doesn't return the content of the body, unless it is a redirection page, so line `and len(response.text) > 500:` "in general" will never be true if second line of check `response = http_request(method="HEAD", url=url)` get response.

As result, devices seem no vulnerable when actually it is.

Data:
```
HEAD /rom-0 HTTP/1.1
Host: 192.168.254.254
Connection: keep-alive
Accept-Encoding: gzip, deflate
Accept: */*
User-Agent: python-requests/2.18.4


HTTP/1.1 200 OK
Content-Type: application/octet-stream
Date: Sat, 01 Jan 2000 00:18:54 GMT
Last-Modified: Wed, 01 Jan 1930 00:18:54 GMT
Content-Length: 16384
Server: RomPager/4.07 UPnP/1.0
EXT:
```

My suggestion is just to check whether content type doesn't return "text/html" as value, so it correct this issue and keep the previous false positive fixed.

`and "html" not in response.headers['Content-Type']:`
or
`and response.headers['Content-Type'] == "application/octet-stream":`

That's it.