### PR TITLE
ZXHN H108N V2.5, module 'ZTE ZXV10 RCE': Fixed false positive issue #305

### DIFF
--- a/routersploit/modules/exploits/routers/zte/zxv10_rce.py
+++ b/routersploit/modules/exploits/routers/zte/zxv10_rce.py
@@ -137,7 +137,9 @@ class Exploit(exploits.Exploit):
                         "Password": self.password}
 
                 response = http_request("POST", url, self.session, data=data)
-                if "Username" not in response.text and "Password" not in response.text:
+                if "Username" not in response.text \
+                        and "Password" not in response.text \
+                        and "404 Not Found" not in response.text :
                     print_success("Successful authentication")
                     return True
         except Exception:

--- a/routersploit/modules/exploits/routers/zte/zxv10_rce.py
+++ b/routersploit/modules/exploits/routers/zte/zxv10_rce.py
@@ -139,7 +139,7 @@ class Exploit(exploits.Exploit):
                 response = http_request("POST", url, self.session, data=data)
                 if "Username" not in response.text \
                         and "Password" not in response.text \
-                        and "404 Not Found" not in response.text:
+                        and response.status_code != 404:
                     print_success("Successful authentication")
                     return True
         except Exception:

--- a/routersploit/modules/exploits/routers/zte/zxv10_rce.py
+++ b/routersploit/modules/exploits/routers/zte/zxv10_rce.py
@@ -139,7 +139,7 @@ class Exploit(exploits.Exploit):
                 response = http_request("POST", url, self.session, data=data)
                 if "Username" not in response.text \
                         and "Password" not in response.text \
-                        and "404 Not Found" not in response.text :
+                        and "404 Not Found" not in response.text:
                     print_success("Successful authentication")
                     return True
         except Exception:


### PR DESCRIPTION
ZXHN H108N V2.5 detected as vulnerable to module 'ZTE ZXV10 RCE' when actually it is not.
DATA:
```
---request begin---
POST /login.gch HTTP/1.1
Host: notvulnerable.dev
Connection: keep-alive
Accept-Encoding: gzip, deflate
Accept: */*
User-Agent: python-requests/2.18.4
Content-Length: 52
Content-Type: application/x-www-form-urlencoded

Frm_Logintoken=&Username=root&Password=W%21n0%26oO7.
---request end---

---response begin---
HTTP/1.1 404 Not Found
Server: Mini web server 1.0 ZTE corp 2005.
Accept-Ranges: bytes
Connection: close
Content-Type: text/html; charset=iso-8859-1
Cache-Control: no-cache,no-store

<HTML>
<HEAD><TITLE>404 Not Found</TITLE></HEAD>
<BODY BGCOLOR="#FFFFFF" TEXT="#000000" LINK="#2020ff" VLINK="#4040cc">
<H2>404 Not Found</H2>
The requested URL was not found on this server.
<HR>
<ADDRESS><A HREF="http://www.zte.com.cn">Mini web server 1.0 ZTE corp 2005.</A></ADDRESS>
</BODY>
</HTML>
---response end---
```
I've only added one more simply check.