### PR TITLE
Allows Python to work with macOS

### DIFF
--- a/rsf.py
+++ b/rsf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 
 from __future__ import print_function
 


### PR DESCRIPTION
Python2 doesn't exist (by default) on macOS, however python2.7 does.