### PR TITLE
Changed python2 to python

### DIFF
--- a/rsf.py
+++ b/rsf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 from __future__ import print_function
 


### PR DESCRIPTION
`python2` doesn't exist (by default) on macOS, however `python2.7` does.
Also, `requests` doesn't work on `python2.7`, however it does work on `python`.
And Python 2.7 is the default (`python`) for most (UNIX) systems.